### PR TITLE
Add rename functionality for custom AI-generated workouts

### DIFF
--- a/frontend/src/pages/AiWorkoutPage.jsx
+++ b/frontend/src/pages/AiWorkoutPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import TopBar from '../components/TopBar';
 import DeviceModal from '../components/DeviceModal';
@@ -126,6 +126,7 @@ export default function AiWorkoutPage() {
   const [intensity, setIntensity] = useState('moderate');
   const [fitnessLevel, setFitnessLevel] = useState('intermediate');
   const [notes, setNotes] = useState('');
+  const [customName, setCustomName] = useState('');
 
   // Generation state
   const [step, setStep] = useState('form'); // 'form' | 'loading' | 'preview' | 'saved'
@@ -135,7 +136,50 @@ export default function AiWorkoutPage() {
   const [error, setError] = useState(null);
   const [savedWorkoutId, setSavedWorkoutId] = useState(null);
 
+  // Editable name in preview
+  const [editingName, setEditingName] = useState(false);
+  const [editNameValue, setEditNameValue] = useState('');
+  const editNameRef = useRef(null);
+
   const apiKeyConfigured = useMemo(() => hasAiKey(), [step]);
+
+  // Focus the name input when entering edit mode
+  useEffect(() => {
+    if (editingName && editNameRef.current) {
+      editNameRef.current.focus();
+      editNameRef.current.select();
+    }
+  }, [editingName]);
+
+  const startEditingName = useCallback(() => {
+    setEditNameValue(preview?.name || '');
+    setEditingName(true);
+  }, [preview]);
+
+  const confirmEditName = useCallback(() => {
+    const trimmed = editNameValue.trim();
+    if (trimmed && trimmed !== preview?.name) {
+      setPreview(prev => ({ ...prev, name: trimmed }));
+      // Update the name in the XML so it persists when saved
+      if (generatedXml) {
+        setGeneratedXml(xml => xml.replace(/<name>[^<]*<\/name>/, `<name>${trimmed}</name>`));
+      }
+    }
+    setEditingName(false);
+  }, [editNameValue, preview, generatedXml]);
+
+  const cancelEditName = useCallback(() => {
+    setEditingName(false);
+  }, []);
+
+  const handleEditNameKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      confirmEditName();
+    } else if (e.key === 'Escape') {
+      cancelEditName();
+    }
+  }, [confirmEditName, cancelEditName]);
 
   const handleGenerate = useCallback(async () => {
     setError(null);
@@ -150,8 +194,12 @@ export default function AiWorkoutPage() {
     }, 1800);
 
     try {
-      const xml = await generateWorkout({ durationMinutes, goal, intensity, fitnessLevel, notes });
+      let xml = await generateWorkout({ durationMinutes, goal, intensity, fitnessLevel, notes });
       clearInterval(msgInterval);
+      // Apply custom name if the user provided one
+      if (customName.trim()) {
+        xml = xml.replace(/<name>[^<]*<\/name>/, `<name>${customName.trim()}</name>`);
+      }
       setGeneratedXml(xml);
       setPreview(parseXmlPreview(xml));
       setStep('preview');
@@ -160,7 +208,7 @@ export default function AiWorkoutPage() {
       setError(err.message || 'Generation failed');
       setStep('form');
     }
-  }, [durationMinutes, goal, intensity, fitnessLevel, notes]);
+  }, [durationMinutes, goal, intensity, fitnessLevel, notes, customName]);
 
   const handleRegenerate = useCallback(() => {
     setSavedWorkoutId(null);
@@ -299,6 +347,18 @@ export default function AiWorkoutPage() {
               </section>
 
               <section className="ai-section">
+                <h2 className="ai-section-title">Workout Name <span className="ai-optional">(optional)</span></h2>
+                <input
+                  type="text"
+                  className="ai-name-input"
+                  placeholder="Leave blank to auto-generate a name"
+                  value={customName}
+                  onChange={(e) => setCustomName(e.target.value)}
+                  maxLength={80}
+                />
+              </section>
+
+              <section className="ai-section">
                 <h2 className="ai-section-title">Additional Notes <span className="ai-optional">(optional)</span></h2>
                 <textarea
                   className="ai-notes-input"
@@ -370,7 +430,31 @@ export default function AiWorkoutPage() {
                       </span>
                     )}
                   </div>
-                  <h2 className="ai-preview-name">{preview.name}</h2>
+                  {editingName ? (
+                    <div className="ai-preview-name-edit">
+                      <input
+                        ref={editNameRef}
+                        type="text"
+                        className="ai-preview-name-input"
+                        value={editNameValue}
+                        onChange={(e) => setEditNameValue(e.target.value)}
+                        onKeyDown={handleEditNameKeyDown}
+                        onBlur={confirmEditName}
+                        maxLength={80}
+                      />
+                    </div>
+                  ) : (
+                    <h2
+                      className="ai-preview-name ai-preview-name-editable"
+                      onClick={startEditingName}
+                      title="Click to rename"
+                    >
+                      {preview.name}
+                      <svg className="ai-edit-icon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
+                      </svg>
+                    </h2>
+                  )}
                   <div className="ai-preview-duration">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                       <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"/>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { Link } from 'react-router-dom';
 import TopBar from '../components/TopBar';
 import DeviceModal from '../components/DeviceModal';
-import { deleteCustomWorkout } from '../services/aiWorkoutGenerator';
+import { deleteCustomWorkout, renameCustomWorkout } from '../services/aiWorkoutGenerator';
 import {
   loadCachedWorkouts,
   loadCachedWorkoutsTimestamp,
@@ -23,6 +23,9 @@ export default function HomePage() {
   const [isDeviceModalOpen, setIsDeviceModalOpen] = useState(false);
   const [rideHistory, setRideHistory] = useState([]);
   const [deletingId, setDeletingId] = useState(null);
+  const [renamingId, setRenamingId] = useState(null);
+  const [renameValue, setRenameValue] = useState('');
+  const renameInputRef = useRef(null);
   const [myWorkouts, setMyWorkouts] = useState(() => loadCustomWorkouts());
   const [apiStatus, setApiStatus] = useState('loading'); // 'loading' | 'ok' | 'cached' | 'offline'
   const [cachedAt, setCachedAt] = useState(null);
@@ -225,6 +228,45 @@ export default function HomePage() {
     }
   }, []);
 
+  const handleStartRename = useCallback((e, workout) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setRenamingId(workout.id);
+    setRenameValue(workout.name);
+  }, []);
+
+  const handleConfirmRename = useCallback(() => {
+    const trimmed = renameValue.trim();
+    if (trimmed && renamingId) {
+      renameCustomWorkout(renamingId, trimmed);
+      setMyWorkouts(loadCustomWorkouts());
+    }
+    setRenamingId(null);
+    setRenameValue('');
+  }, [renameValue, renamingId]);
+
+  const handleCancelRename = useCallback(() => {
+    setRenamingId(null);
+    setRenameValue('');
+  }, []);
+
+  const handleRenameKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleConfirmRename();
+    } else if (e.key === 'Escape') {
+      handleCancelRename();
+    }
+  }, [handleConfirmRename, handleCancelRename]);
+
+  // Focus rename input when it appears
+  useEffect(() => {
+    if (renamingId && renameInputRef.current) {
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [renamingId]);
+
   const durationLabels = { short: '0\u201330 min', medium: '31\u201360 min', long: '60+ min' };
   const isApiUnavailable = apiStatus === 'cached' || apiStatus === 'offline';
   const cachedDate = cachedAt ? new Date(cachedAt) : null;
@@ -312,7 +354,22 @@ export default function HomePage() {
                             </div>
                             <div className="workout-card-content">
                               <div className="workout-type">AI Generated</div>
-                              <h3 className="workout-title">{workout.name}</h3>
+                              {renamingId === workout.id ? (
+                                <div className="workout-rename-row" onClick={(e) => e.preventDefault()}>
+                                  <input
+                                    ref={renameInputRef}
+                                    type="text"
+                                    className="workout-rename-input"
+                                    value={renameValue}
+                                    onChange={(e) => setRenameValue(e.target.value)}
+                                    onKeyDown={handleRenameKeyDown}
+                                    onBlur={handleConfirmRename}
+                                    maxLength={80}
+                                  />
+                                </div>
+                              ) : (
+                                <h3 className="workout-title">{workout.name}</h3>
+                              )}
                               <div className="workout-meta">
                                 <div className="workout-meta-item">
                                   <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -329,17 +386,29 @@ export default function HomePage() {
                               )}
                             </div>
                           </Link>
-                          <button
-                            className={`workout-card-delete ${deletingId === workout.id ? 'deleting' : ''}`}
-                            onClick={(e) => handleDeleteCustomWorkout(e, workout.id)}
-                            disabled={deletingId === workout.id}
-                            aria-label="Delete workout"
-                            title="Delete workout"
-                          >
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                              <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
-                            </svg>
-                          </button>
+                          <div className="workout-card-actions">
+                            <button
+                              className="workout-card-rename"
+                              onClick={(e) => handleStartRename(e, workout)}
+                              aria-label="Rename workout"
+                              title="Rename workout"
+                            >
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
+                              </svg>
+                            </button>
+                            <button
+                              className={`workout-card-delete ${deletingId === workout.id ? 'deleting' : ''}`}
+                              onClick={(e) => handleDeleteCustomWorkout(e, workout.id)}
+                              disabled={deletingId === workout.id}
+                              aria-label="Delete workout"
+                              title="Delete workout"
+                            >
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+                              </svg>
+                            </button>
+                          </div>
                         </div>
                       );
                     })}

--- a/frontend/src/services/aiWorkoutGenerator.js
+++ b/frontend/src/services/aiWorkoutGenerator.js
@@ -8,7 +8,7 @@
  *   { provider: 'openai' | 'anthropic', apiKey: string }
  */
 
-import { saveCustomWorkoutLocally, removeCustomWorkoutLocally } from './dataManager.js';
+import { saveCustomWorkoutLocally, removeCustomWorkoutLocally, renameCustomWorkoutLocally } from './dataManager.js';
 import { parseOrwXml } from './workoutParser.js';
 
 const AI_SETTINGS_KEY = 'openride_ai_settings';
@@ -257,11 +257,21 @@ export async function generateWorkout(params) {
 /**
  * Parse and save a generated workout entirely client-side.
  * No backend call is made — the workout lives in localStorage only.
- * Returns the full parsed workout object (same shape as /api/workouts/:id).
+ *
+ * @param {string} xml           Raw .orw XML
+ * @param {string} [customName]  Optional name override. When provided the
+ *                                <name> tag in the XML is replaced before
+ *                                parsing so the custom name flows through to
+ *                                the id, display name, and stored XML.
+ * @returns {object} The full parsed workout object (same shape as /api/workouts/:id).
  */
-export function saveWorkout(xml) {
-  const parsed = parseOrwXml(xml); // generates id + parses all elements
-  saveCustomWorkoutLocally({ ...parsed, xml });
+export function saveWorkout(xml, customName) {
+  let finalXml = xml;
+  if (customName && customName.trim()) {
+    finalXml = xml.replace(/<name>[^<]*<\/name>/, `<name>${customName.trim()}</name>`);
+  }
+  const parsed = parseOrwXml(finalXml);
+  saveCustomWorkoutLocally({ ...parsed, xml: finalXml });
   return parsed;
 }
 
@@ -270,4 +280,11 @@ export function saveWorkout(xml) {
  */
 export function deleteCustomWorkout(id) {
   removeCustomWorkoutLocally(id);
+}
+
+/**
+ * Rename a custom workout in localStorage.
+ */
+export function renameCustomWorkout(id, newName) {
+  renameCustomWorkoutLocally(id, newName);
 }

--- a/frontend/src/services/dataManager.js
+++ b/frontend/src/services/dataManager.js
@@ -71,6 +71,24 @@ export function removeCustomWorkoutLocally(id) {
   persistCustomWorkouts(list);
 }
 
+/**
+ * Rename a custom workout in localStorage.
+ * Updates both the stored name and the <name> tag inside the raw XML.
+ */
+export function renameCustomWorkoutLocally(id, newName) {
+  const list = loadCustomWorkouts();
+  const idx = list.findIndex(w => w.id === id);
+  if (idx < 0) return;
+  list[idx].name = newName;
+  if (list[idx].xml) {
+    list[idx].xml = list[idx].xml.replace(
+      /<name>[^<]*<\/name>/,
+      `<name>${newName}</name>`
+    );
+  }
+  persistCustomWorkouts(list);
+}
+
 // ─── Cached backend workouts (for offline use) ──────────────────────────────
 
 export function loadCachedWorkouts() {

--- a/frontend/src/styles/aiworkout.css
+++ b/frontend/src/styles/aiworkout.css
@@ -270,6 +270,29 @@
   color: var(--muted-45);
 }
 
+/* Workout name input */
+.ai-name-input {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  padding: 0.75rem;
+  font-family: inherit;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease;
+}
+
+.ai-name-input:focus {
+  outline: none;
+  border-color: #00d4ff;
+}
+
+.ai-name-input::placeholder {
+  color: var(--input-placeholder);
+}
+
 /* Notes textarea */
 .ai-notes-input {
   width: 100%;
@@ -473,6 +496,46 @@
   font-size: 1.5rem;
   font-weight: 700;
   margin: 0 0 0.5rem;
+}
+
+.ai-preview-name-editable {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: color 0.15s ease;
+}
+
+.ai-preview-name-editable:hover {
+  color: #00d4ff;
+}
+
+.ai-edit-icon {
+  opacity: 0.3;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
+}
+
+.ai-preview-name-editable:hover .ai-edit-icon {
+  opacity: 0.7;
+}
+
+.ai-preview-name-edit {
+  margin: 0 0 0.5rem;
+}
+
+.ai-preview-name-input {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid #00d4ff;
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 1.35rem;
+  font-weight: 700;
+  padding: 0.375rem 0.625rem;
+  font-family: inherit;
+  box-sizing: border-box;
+  outline: none;
 }
 
 .ai-preview-duration {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1799,15 +1799,28 @@ h1, h2, h3, h4 {
   box-shadow: 0 4px 14px rgba(var(--primary-rgb), 0.3);
 }
 
-/* Workout card wrapper for delete button positioning */
+/* Workout card wrapper for action button positioning */
 .workout-card-wrapper {
   position: relative;
 }
 
-.workout-card-delete {
+.workout-card-actions {
   position: absolute;
   top: 0.625rem;
   right: 0.625rem;
+  display: flex;
+  gap: 0.375rem;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 2;
+}
+
+.workout-card-wrapper:hover .workout-card-actions {
+  opacity: 1;
+}
+
+.workout-card-rename,
+.workout-card-delete {
   width: 28px;
   height: 28px;
   border-radius: 6px;
@@ -1818,13 +1831,13 @@ h1, h2, h3, h4 {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  opacity: 0;
   transition: all 0.15s ease;
-  z-index: 2;
 }
 
-.workout-card-wrapper:hover .workout-card-delete {
-  opacity: 1;
+.workout-card-rename:hover {
+  background: rgba(0, 212, 255, 0.2);
+  border-color: rgba(0, 212, 255, 0.5);
+  color: #00d4ff;
 }
 
 .workout-card-delete:hover {
@@ -1836,6 +1849,25 @@ h1, h2, h3, h4 {
 .workout-card-delete.deleting {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Inline rename input */
+.workout-rename-row {
+  margin-bottom: 0.25rem;
+}
+
+.workout-rename-input {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid #00d4ff;
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  box-sizing: border-box;
+  outline: none;
 }
 
 /* ── Theme toggle button ─────────────────────────────────────────────── */
@@ -1865,6 +1897,7 @@ h1, h2, h3, h4 {
   box-shadow: 0 1px 12px rgba(0, 30, 60, 0.08);
 }
 
+[data-theme="light"] .workout-card-rename,
 [data-theme="light"] .workout-card-delete {
   background: rgba(0, 0, 0, 0.35);
   border-color: rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
## Summary
This PR adds the ability to rename custom AI-generated workouts both during creation and after saving. Users can now provide a custom name when generating a workout, edit the name in the preview before saving, and rename saved workouts directly from the home page.

## Key Changes

- **HomePage.jsx**: Added rename UI and handlers for saved custom workouts
  - New state for tracking rename mode (`renamingId`, `renameValue`)
  - Inline rename input that appears when clicking the rename button
  - Keyboard support (Enter to confirm, Escape to cancel)
  - Auto-focus and select text when entering rename mode
  - New rename button alongside the delete button in workout cards

- **AiWorkoutPage.jsx**: Added custom name input and editable preview name
  - New "Workout Name" optional input field in the generation form
  - Editable workout name in the preview section (click to edit)
  - Name editing with keyboard support and auto-focus
  - Custom name is applied to the generated XML before saving

- **aiWorkoutGenerator.js**: Enhanced workout saving and added rename function
  - Updated `saveWorkout()` to accept optional `customName` parameter
  - New `renameCustomWorkout()` function to rename saved workouts
  - XML name tag replacement logic to persist custom names

- **dataManager.js**: Added `renameCustomWorkoutLocally()` function
  - Updates both the workout name and the `<name>` tag in stored XML
  - Ensures consistency between display name and raw workout data

- **Styling** (aiworkout.css & index.css):
  - New styles for name input fields with focus states
  - Editable name styling with hover effects and edit icon
  - Grouped action buttons (rename + delete) with improved layout
  - Inline rename input styling for workout cards

## Implementation Details

- Rename operations update both the in-memory name and the underlying XML to maintain consistency
- All rename inputs auto-focus and select existing text for better UX
- Keyboard shortcuts (Enter/Escape) work consistently across all rename interfaces
- Blur events confirm renames, allowing quick edits without explicit confirmation
- Maximum name length is 80 characters across all inputs

https://claude.ai/code/session_01AFg83nuWbG1RzzyTcv2Hzg