### PR TITLE
Add Clear All Data button to Settings with confirmation modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,18 @@ Plan your week by assigning workouts to each day of the week. Drag and drop to r
 
 Generate a personalised workout on the fly using an LLM. Answer a few questions — duration, training goal, intensity, fitness level — and the AI creates a structured `.orw` workout tailored to you.
 
-- Bring your own API key (OpenAI or Anthropic) — the key is stored only in your browser and sent directly to the AI provider; it never touches Open Ride servers
+- Bring your own API key (OpenAI or Anthropic) — **this is entirely optional**; the key is stored only in your browser and sent directly to the AI provider; it never touches Open Ride servers
 - Generated workouts are saved to **My Workouts** and stored in `localStorage` — no account or backend needed
 - Works offline after first generation (saved workouts persist locally)
+
+> **API key security notice:** Bringing your own API key is optional and should be done with caution.
+> Your key is stored in your browser's `localStorage` and is readable by anyone with access to
+> DevTools on your machine. Browser extensions may also be able to read it. Open Ride loads no
+> external scripts, which removes the main XSS vector, but you remain responsible for the security
+> of your own device and browser environment.
+> **The authors and contributors of Open Ride accept no liability for any leakage, theft, or
+> unauthorized use of API keys entered into this application.**
+> If you use a shared or public computer, use private/incognito mode and clear site data when done.
 
 ### My Workouts
 

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -67,6 +67,7 @@ export default function SettingsPage() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [importStatus, setImportStatus] = useState(null); // null | 'success' | 'error'
   const [importMessage, setImportMessage] = useState('');
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [form, setForm] = useState(() => {
     const settings = loadSettings();
     return {
@@ -145,6 +146,11 @@ export default function SettingsPage() {
       weight: convertWeight(defaults.weight, defaults.units),
       bikeWeight: convertWeight(defaults.bikeWeight, defaults.units)
     });
+  };
+
+  const handleClearAllData = () => {
+    localStorage.clear();
+    window.location.reload();
   };
 
   const handleEmulatorToggle = () => {
@@ -589,6 +595,26 @@ export default function SettingsPage() {
                     {importMessage}
                   </div>
                 )}
+
+                <div className="data-mgmt-row data-mgmt-row--danger">
+                  <div className="setting-info">
+                    <label>Clear All Data</label>
+                    <p className="setting-description">
+                      Permanently delete everything stored by Open Ride in this browser — settings,
+                      ride history, training program, custom workouts, and your AI API key.
+                      <strong> This cannot be undone.</strong>
+                    </p>
+                  </div>
+                  <button
+                    className="btn-danger data-mgmt-btn"
+                    onClick={() => setShowClearConfirm(true)}
+                  >
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+                    </svg>
+                    Clear All Data
+                  </button>
+                </div>
               </div>
             </section>
 
@@ -659,6 +685,33 @@ export default function SettingsPage() {
       </main>
 
       <DeviceModal isOpen={isDeviceModalOpen} onClose={() => setIsDeviceModalOpen(false)} />
+
+      {showClearConfirm && (
+        <div className="clear-data-overlay" onClick={() => setShowClearConfirm(false)}>
+          <div className="clear-data-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="clear-data-modal-icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
+              </svg>
+            </div>
+            <h3>Clear all data?</h3>
+            <p>This will permanently delete everything Open Ride has stored in this browser:</p>
+            <ul className="clear-data-list">
+              <li>Settings and athlete profile</li>
+              <li>Ride history</li>
+              <li>Training program</li>
+              <li>Custom and AI-generated workouts</li>
+              <li>Device preferences</li>
+              <li>AI API key</li>
+            </ul>
+            <p className="clear-data-warning">This action cannot be undone. Export a backup first if you want to keep your data.</p>
+            <div className="clear-data-modal-actions">
+              <button className="btn-secondary" onClick={() => setShowClearConfirm(false)}>Cancel</button>
+              <button className="btn-danger" onClick={handleClearAllData}>Yes, clear everything</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/styles/settings.css
+++ b/frontend/src/styles/settings.css
@@ -407,6 +407,101 @@
   color: #ff8080;
 }
 
+/* Danger button */
+.btn-danger {
+  padding: 0.875rem 2rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+  background: rgba(220, 38, 38, 0.15);
+  color: #f87171;
+  border: 1px solid rgba(220, 38, 38, 0.35);
+}
+
+.btn-danger:hover {
+  background: rgba(220, 38, 38, 0.25);
+  border-color: rgba(220, 38, 38, 0.6);
+  color: #fca5a5;
+}
+
+/* Danger data management row */
+.data-mgmt-row--danger {
+  border: 1px solid rgba(220, 38, 38, 0.2);
+}
+
+/* Clear all data confirmation overlay */
+.clear-data-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 1rem;
+}
+
+.clear-data-modal {
+  background: #1a1a2e;
+  border: 1px solid rgba(220, 38, 38, 0.3);
+  border-radius: 16px;
+  padding: 2rem;
+  max-width: 440px;
+  width: 100%;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
+}
+
+.clear-data-modal-icon {
+  color: #f87171;
+  margin-bottom: 1rem;
+}
+
+.clear-data-modal h3 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  color: var(--text-primary);
+}
+
+.clear-data-modal p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.clear-data-list {
+  margin: 0 0 1rem 1.25rem;
+  padding: 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+.clear-data-warning {
+  font-size: 0.85rem;
+  color: #f87171;
+  font-weight: 500;
+  margin-bottom: 1.5rem !important;
+}
+
+.clear-data-modal-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.clear-data-modal-actions .btn-secondary {
+  padding: 0.7rem 1.5rem;
+}
+
+.clear-data-modal-actions .btn-danger {
+  padding: 0.7rem 1.5rem;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .settings-wrapper {


### PR DESCRIPTION
- Add a 'Clear All Data' danger button in the Data Management section
  that wipes all localStorage keys and reloads the page
- Guard the action behind an in-page confirmation modal that lists every
  category of data that will be deleted and warns the action is irreversible
- Style the button and modal with a red/danger colour scheme distinct from
  existing actions
- Update README: mark the AI API key as optional and add a liability
  disclaimer noting that authors and contributors bear no responsibility
  for API key leakage

https://claude.ai/code/session_01M6HwKxUSFmuJfcbspVGxVZ