### PR TITLE
Fix calorie calculation: apply cycling efficiency factor

### DIFF
--- a/frontend/src/pages/WorkoutPage.jsx
+++ b/frontend/src/pages/WorkoutPage.jsx
@@ -462,7 +462,9 @@ export default function WorkoutPage() {
       : 0;
     const distance = telemetryRef.current.distance || 0;
     const totalKJ = (avgPower * duration) / 1000;
-    const calories = Math.round(totalKJ / 4.184);
+    // Cycling standard: 1 kJ mechanical ≈ 1 kcal (body ~24% efficient: 1/0.24/4.184 ≈ 1.0)
+    // Same convention used by Garmin, Wahoo, TrainingPeaks
+    const calories = Math.round(totalKJ);
     const intensityFactor = ftp > 0 ? (avgPower / ftp).toFixed(2) : '--';
 
     const stats = {


### PR DESCRIPTION
The previous formula (kcal = kJ / 4.184) treated the body as 100%
mechanically efficient, underreporting calories by ~4x. The cycling
industry standard (Garmin, Wahoo, TrainingPeaks) is 1 kJ ≈ 1 kcal,
derived from ~24% mechanical efficiency: 1 kJ / 0.24 / 4.184 ≈ 1 kcal.

This brings estimates in line with device readings like Apple Watch.
Example: 40 min at 150W → 360 kJ → 360 kcal (was 86 kcal).

https://claude.ai/code/session_01JpqZskcrNranabupxnrPUN